### PR TITLE
Shutdown logging + optional timeout

### DIFF
--- a/sfio-tokio-ffi/Cargo.toml
+++ b/sfio-tokio-ffi/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sfio-tokio-ffi"
 description = "An oo-bindgen model for using Tokio in an FFI environment"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 license-file = "../LICENSE"
 readme = "../README.md"

--- a/sfio-tokio-ffi/Cargo.toml
+++ b/sfio-tokio-ffi/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sfio-tokio-ffi"
 description = "An oo-bindgen model for using Tokio in an FFI environment"
-version = "0.5.1"
+version = "0.6.0"
 edition = "2021"
 license-file = "../LICENSE"
 readme = "../README.md"

--- a/sfio-tokio-ffi/Cargo.toml
+++ b/sfio-tokio-ffi/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sfio-tokio-ffi"
 description = "An oo-bindgen model for using Tokio in an FFI environment"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
 license-file = "../LICENSE"
 readme = "../README.md"

--- a/sfio-tokio-ffi/Cargo.toml
+++ b/sfio-tokio-ffi/Cargo.toml
@@ -9,4 +9,4 @@ homepage = "https://github.com/stepfunc/tokio-ffi"
 repository = "https://github.com/stepfunc/tokio-ffi"
 
 [dependencies]
-oo-bindgen = { git = "https://github.com/stepfunc/oo_bindgen.git", branch = "feature/drop-safe-futures" }
+oo-bindgen = "0.7"

--- a/sfio-tokio-ffi/Cargo.toml
+++ b/sfio-tokio-ffi/Cargo.toml
@@ -9,4 +9,4 @@ homepage = "https://github.com/stepfunc/tokio-ffi"
 repository = "https://github.com/stepfunc/tokio-ffi"
 
 [dependencies]
-oo-bindgen = "0.6.0"
+oo-bindgen = { git = "https://github.com/stepfunc/oo_bindgen.git", branch = "feature/drop-safe-futures" }

--- a/sfio-tokio-ffi/runtime.rs
+++ b/sfio-tokio-ffi/runtime.rs
@@ -13,8 +13,8 @@ pub enum RuntimeError {
 }
 
 pub struct Runtime {
-    pub(crate) inner: Option<tokio::runtime::Runtime>,
-    pub(crate) shutdown_timeout: Option<Duration>,
+    inner: Option<tokio::runtime::Runtime>,
+    shutdown_timeout: Option<Duration>,
 }
 
 impl Runtime {
@@ -25,35 +25,49 @@ impl Runtime {
         }
     }
 
-    pub fn handle(&self) -> RuntimeHandle {
+    pub(crate) fn handle(&self) -> RuntimeHandle {
         RuntimeHandle {
             inner: self.inner.as_ref().unwrap().handle().clone(),
         }
+    }
+
+    pub(crate) fn enter(&self) -> tokio::runtime::EnterGuard<'_> {
+        self.inner.as_ref().unwrap().enter()
     }
 }
 
 impl Drop for Runtime {
     fn drop(&mut self) {
-        if let (Some(runtime), Some(timeout)) = (self.inner.take(), self.shutdown_timeout) {
-            runtime.shutdown_timeout(timeout)
+        let runtime = self.inner.take().unwrap();
+        match self.shutdown_timeout {
+            Some(timeout) => {
+                tracing::info!("beginning runtime shutdown (timeout == {timeout:?})");
+                runtime.shutdown_timeout(timeout);
+                tracing::info!("runtime shutdown complete");
+            }
+            None => {
+                tracing::info!("beginning runtime shutdown (no timeout)");
+                drop(runtime);
+                tracing::info!("runtime shutdown complete");
+            }
         }
     }
 }
 
 #[derive(Clone)]
-pub struct RuntimeHandle {
+pub(crate) struct RuntimeHandle {
     inner: Handle,
 }
 
 impl RuntimeHandle {
-    pub fn block_on<F: Future>(&self, future: F) -> Result<F::Output, RuntimeError> {
+    pub(crate) fn block_on<F: Future>(&self, future: F) -> Result<F::Output, RuntimeError> {
         if Handle::try_current().is_ok() {
             return Err(RuntimeError::CannotBlockWithinAsync);
         }
         Ok(self.inner.block_on(future))
     }
 
-    pub fn spawn<F>(&self, future: F) -> Result<(), RuntimeError>
+    pub(crate) fn spawn<F>(&self, future: F) -> Result<(), RuntimeError>
         where
             F: Future + Send + 'static,
             F::Output: Send + 'static,

--- a/sfio-tokio-ffi/runtime.rs
+++ b/sfio-tokio-ffi/runtime.rs
@@ -80,7 +80,7 @@ pub(crate) unsafe fn runtime_create(
     };
 
     tracing::info!("creating runtime with {} threads", num_threads);
-    let runtime = build_runtime(|r| r.worker_threads(num_threads as usize))
+    let runtime = build_runtime(|r| r.worker_threads(num_threads))
         .map_err(|_| RuntimeError::FailedToCreateRuntime)?;
     Ok(Box::into_raw(Box::new(Runtime::new(runtime))))
 }

--- a/sfio-tokio-ffi/src/lib.rs
+++ b/sfio-tokio-ffi/src/lib.rs
@@ -11,7 +11,6 @@
     patterns_in_fns_without_body,
     pub_use_of_private_extern_crate,
     unknown_crate_types,
-    const_err,
     order_dependent_trait_objects,
     illegal_floating_point_literal_pattern,
     improper_ctypes,

--- a/sfio-tokio-ffi/src/lib.rs
+++ b/sfio-tokio-ffi/src/lib.rs
@@ -83,10 +83,21 @@ pub fn define(
                 .details("This method will gracefully wait for all asynchronous operation to end before returning")
         )?;
 
+    let set_shutdown_timeout =
+        lib.define_method("set_shutdown_timeout", runtime.clone())?
+            .doc(
+                    doc("By default, when the runtime shuts down, it does so without a timeout and waits indefinitely for all spawned tasks to yield.")
+                    .details("Setting this value will put a maximum time bound on the eventual shutdown. Threads that have not exited within this timeout will be terminated.")
+                        .warning("This can leak memory. This method should only be used if the the entire application is being shut down so that memory can be cleaned up by the OS.")
+            )?
+            .param("timeout", BasicType::Duration(DurationType::Seconds), "Maximum number of seconds to wait for the runtime to shut down")?
+            .build()?;
+
     let runtime = lib
         .define_class(&runtime)?
         .constructor(constructor)?
         .destructor(destructor)?
+        .method(set_shutdown_timeout)?
         .custom_destroy("shutdown")?
         .doc("Handle to the underlying runtime")?
         .build()?;

--- a/test/Cargo.toml
+++ b/test/Cargo.toml
@@ -10,5 +10,5 @@ lazy_static = "1"
 num_cpus = "1"
 
 [build-dependencies]
-oo-bindgen = "0.6.0"
+oo-bindgen = { git = "https://github.com/stepfunc/oo_bindgen.git", branch = "feature/drop-safe-futures" }
 sfio-tokio-ffi = { path = "../sfio-tokio-ffi" }

--- a/test/Cargo.toml
+++ b/test/Cargo.toml
@@ -10,5 +10,5 @@ lazy_static = "1"
 num_cpus = "1"
 
 [build-dependencies]
-oo-bindgen = { git = "https://github.com/stepfunc/oo_bindgen.git", branch = "feature/drop-safe-futures" }
+oo-bindgen = "0.7"
 sfio-tokio-ffi = { path = "../sfio-tokio-ffi" }

--- a/test/src/lib.rs
+++ b/test/src/lib.rs
@@ -1,5 +1,6 @@
 #[allow(dead_code)]
 pub mod ffi;
+#[allow(dead_code)]
 mod runtime;
 
 pub(crate) use runtime::*;


### PR DESCRIPTION
* Mirgates to oo-bingen 0.7 with drop-safe future interfaces
* Use `tokio::runtime::Handle` instead of `Arc<tokio::runtime::Runtime>` so that shutdown can happen on deterministic thread
* Add ability to optional shutdown with a timeout
* Add logging to to the shutdown process